### PR TITLE
Added qmio additions

### DIFF
--- a/backends/qpu_felisa/run.py
+++ b/backends/qpu_felisa/run.py
@@ -3,7 +3,7 @@ import sys
 import json
 from pathlib import Path
 from lx7.zmq_wrapper import ZMQClient
-
+import time
 
 if len(sys.argv) != 5:
     print("Usage: python3.8 run.py <compiled_circuit.x> <results.json> <execution_metrics.json> <num_shots>")
@@ -25,7 +25,12 @@ config.repeats = num_shots
 config.optimizations = TketOptimizations.Empty
 
 zmq_client = ZMQClient()
+# Time measure in the execution
+# Compilation in CS + Execution to QPU + Comming back results from QPU
+start = time.time()
 output = zmq_client.execute_task(circuit, config.to_json())
+end = time.time()
+elapsed = {"elapsed_time": end - time}
 
 if "results" in output:
     with open(results_filename, "w") as f:
@@ -33,6 +38,7 @@ if "results" in output:
 
     with open(execution_metrics_filename, "w") as f:
         json.dump(output["execution_metrics"], f)
+        json.dump(elapsed, f)
 
     print(output["results"])
 else:

--- a/backends/simulator_qulacs/run.py
+++ b/backends/simulator_qulacs/run.py
@@ -1,19 +1,39 @@
 from qulacs import QuantumCircuit, QuantumState, QuantumCircuitSimulator, Observable
 from qulacs import converter
+import sys
+import json
+from pathlib import Path
+import time
 
-# Hay que quitar los creg y las medidas porque no está soportado por la autotraducción
-qasm_string = """
-OPENQASM 2.0;
-include "qelib1.inc";
 
-qreg q[2];
+if len(sys.argv) != 5:
+    print("Usage: python3.8 run.py <compiled_circuit.x> <results.json> <execution_metrics.json> <num_shots>")
+    sys.exit(1)
 
-h q[0];           
-cx q[0],q[1];     
-"""
+circuit_filename = sys.argv[1]
+results_filename = sys.argv[2]
+execution_metrics_filename = sys.argv[3]
+num_shots = int(sys.argv[4])
+
+if Path(circuit_filename).is_file():
+    print(f"Reading circuit file: {circuit_filename}")
+    circuit = Path(circuit_filename).read_text()
+
+## Hay que quitar los creg y las medidas porque no está soportado por la autotraducción
+#qasm_string = """
+#OPENQASM 2.0;
+#include "qelib1.inc";
+#
+#qreg q[2];
+#
+#h q[0];
+#cx q[0],q[1];
+#"""
 # Convertir el qasm a un circuito en qulacs
-qc = converter.convert_QASM_to_qulacs_circuit(qasm_string.splitlines())
-print(qc)
+qc = converter.convert_QASM_to_qulacs_circuit(circuit.splitlines())
+
+if DEBUG == 1:
+    print("El circuito en QASM:", qc)
 
 # Instanciar el vector de estado
 qubits = qc.get_qubit_count()
@@ -35,22 +55,24 @@ con qulacs y sacarle rendimiento es mejor hacerlo directo.
 
 # Inicializar el vector de estado en el estado 0
 state.set_zero_state()
-print(state)
+if DEBUG == 1:
+    print("Estado inicializado en cero:", state)
 
 # Inicializar el simulador y simular
 sim = QuantumCircuitSimulator(qc, state)
 sim.simulate()
-print(state)
+if DEBUG == 1:
+    print("Estado tras la aplicación del algoritmo:", state)
 
 ########################################################################
 ########################################################################
 
 # Instanciar un observable y obtener el valor esperado de ese observable
-observable = Observable(1)
-observable.add_operator(1.0, "Z 0")
-
-expectation_value = sim.get_expectation_value(observable)
-print("Valor esperado del observable:", expectation_value)
+#observable = Observable(1)
+#observable.add_operator(1.0, "Z 0")
+#
+#expectation_value = sim.get_expectation_value(observable)
+#print("Valor esperado del observable:", expectation_value)
 
 ########################################################################
 ########################################################################
@@ -72,21 +94,19 @@ def build_ising_hamiltonian(qubits, h_values, J_values):
 
     return hamiltonian
 
-h_values = [0.5, -0.3]
-j_values = [0.4]
+#h_values = [0.5, -0.3]
+#j_values = [0.4]
 
-ising_hamiltonian = build_ising_hamiltonian(qbits, h_values, j_values)
-print("Hamiltoniano de Ising:")
-print(ising_hamiltonian)
+#ising_hamiltonian = build_ising_hamiltonian(qbits, h_values, j_values)
+#print("Hamiltoniano de Ising:")
+#print(ising_hamiltonian)
 
 # Obtener el valor esperado de la energía mínima
-energy_min = sim.get_expectation_value(ising_hamiltonian)
+#energy_min = sim.get_expectation_value(ising_hamiltonian)
 
 ########################################################################
 ########################################################################
 
 # Número de shots y cuentas. Resultado tipo qasm en qmio
-num_shots = 1000
-
 measurement_counts = sim.run_measurement_counts(num_shots)
 print("Número de cuentas tras", num_shots, "shots:", measurement_counts)

--- a/backends/simulator_qulacs/run.py
+++ b/backends/simulator_qulacs/run.py
@@ -42,8 +42,51 @@ sim = QuantumCircuitSimulator(qc, state)
 sim.simulate()
 print(state)
 
+########################################################################
+########################################################################
+
 # Instanciar un observable y obtener el valor esperado de ese observable
 observable = Observable(1)
 observable.add_operator(1.0, "Z 0")
 
-sim.get_expectation_value(observable)
+expectation_value = sim.get_expectation_value(observable)
+print("Valor esperado del observable:", expectation_value)
+
+########################################################################
+########################################################################
+
+# Ising hamiltonian builder
+def build_ising_hamiltonian(qubits, h_values, J_values):
+    if len(h_values) != qubits or len(J_values) != qubits - 1:
+        raise ValueError("La longitud de los valores de h y J debe ser igual al número de qubits y qubits - 1 respectivamente.")
+
+    hamiltonian = Observable(qubits)
+
+    # Términos del campo magnético
+    for i in range(qubits):
+        hamiltonian.add_operator(h_values[i], f"Z {i}")
+
+    # Términos de acoplamiento
+    for i in range(qubits - 1):
+        hamiltonian.add_operator(J_values[i], f"Z {i} Z {i+1}")
+
+    return hamiltonian
+
+h_values = [0.5, -0.3]
+j_values = [0.4]
+
+ising_hamiltonian = build_ising_hamiltonian(qbits, h_values, j_values)
+print("Hamiltoniano de Ising:")
+print(ising_hamiltonian)
+
+# Obtener el valor esperado de la energía mínima
+energy_min = sim.get_expectation_value(ising_hamiltonian)
+
+########################################################################
+########################################################################
+
+# Número de shots y cuentas. Resultado tipo qasm en qmio
+num_shots = 1000
+
+measurement_counts = sim.run_measurement_counts(num_shots)
+print("Número de cuentas tras", num_shots, "shots:", measurement_counts)

--- a/backends/simulator_qulacs/run.sh
+++ b/backends/simulator_qulacs/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -J qulacs_circuit      # Job name
+#SBATCH -o qulacs_circuit.o%j      # Name of stdout output file(%j expands to jobId)
+#SBATCH -e qulacs_circuit.e%j      # Name of stderr output file(%j expands to jobId)
+#SBATCH -p qs        # partition
+#SBATCH -N 1                # Number of nodes, not cores (48 cores/node)
+#SBATCH -n 48                # Total number of MPI tasks (if omitted, n=N)
+#SBATCH -c 1                # Cores per task
+#SBATCH -t 00:10:00         # Run time (hh:mm:ss)
+
+if [[ $# != 4 ]]; then
+    echo $#
+    echo "Usage: run.sh <qulacs_circuit.p> <results.json> <execution_metrics.json> <num_shots>"
+    exit 1
+fi
+
+# Load qulacs module
+module load qulacs-hpcx
+
+# Run the circuit
+python3.8 /mnt/Q_SWAP/qmio/backends/simulator_qulacs/run.py $*

--- a/backends/simulator_qulacs/run_mpi.py
+++ b/backends/simulator_qulacs/run_mpi.py
@@ -5,6 +5,14 @@ import json
 from pathlib import Path
 import time
 
+import numpy as np
+from mpi4py import MPI
+
+mpicomm = MPI.COMM_WORLD
+mpirank = mpicomm.Get_rank()
+mpisize = mpicomm.Get_size()
+globalqubits = int(np.log2(mpisize))
+
 DEBUG=0
 
 if len(sys.argv) != 5:
@@ -38,7 +46,7 @@ if DEBUG == 1:
 
 # Instanciar el vector de estado
 qubits = qc.get_qubit_count()
-state = QuantumState(qubits)    # si fuese en la implementación paralela, QuantumState(qubits, 1) y ademas inicializar el entorno mpi
+state = QuantumState(qubits, use_multi_cpu = True)    # si fuese en la implementación paralela, QuantumState(qubits, 1) y ademas inicializar el entorno mpi
 
 """
 Tendríamos que definir cual es la función báscia
@@ -60,6 +68,8 @@ if DEBUG == 1:
     print("Estado inicializado en cero:", state)
 
 # Inicializar el simulador y simular
+#sim = QuantumCircuitSimulator(qc, state)
+#sim.simulate()
 qc.update_quantum_state(state)
 if DEBUG == 1:
     print("Estado tras la aplicación del algoritmo:", state)
@@ -121,7 +131,8 @@ def contar_ocurrencias(lista=binary_count):
             diccionario[elemento] = 1
     return diccionario
 
-result = contar_ocurrencias()
-print(result)
-dev_type = state.get_device_name()
-print("device", dev_type)
+if mpirank == 0:
+    result = contar_ocurrencias()
+    print(result)
+    dev_type = state.get_device_name()
+    print("device", dev_type)

--- a/backends/simulator_qulacs/run_mpi.sh
+++ b/backends/simulator_qulacs/run_mpi.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH -J qulacs_circuit      # Job name
+#SBATCH -o qulacs_circuit.o%j      # Name of stdout output file(%j expands to jobId)
+#SBATCH -e qulacs_circuit.e%j      # Name of stderr output file(%j expands to jobId)
+#SBATCH -p qs        # partition
+#SBATCH -N 1                # Number of nodes, not cores (48 cores/node)
+#SBATCH -n 48                # Total number of MPI tasks (if omitted, n=N)
+#SBATCH -c 1                # Cores per task
+#SBATCH -t 00:10:00         # Run time (hh:mm:ss)
+
+#set -x
+
+if [[ $# != 4 ]]; then
+    echo $#
+    echo "Usage: run.sh <qulacs_circuit.p> <results.json> <execution_metrics.json> <num_shots>"
+    exit 1
+fi
+
+calcular_potencia() {
+    local nodos=$SLURM_NNODES
+    local resultado=$((nodos * 48))
+    local potencia=1
+
+    while [ $((potencia * 2)) -le $resultado ]; do
+        potencia=$((potencia * 2))
+    done
+    export SIZE=$potencia
+}
+# Función para sacar de manera automática el número de tareas.
+calcular_potencia
+# Load qulacs module
+module load qulacs-hpcx
+# Run the circuit
+
+OMP_NUM_THREADS=12
+QULACS_NUM_THREADS=12
+
+mpirun -npernode 4 numactl -N 0-3 -m 0-3 python3.8 /home/cesga/acaride/Trainning_Qulacs/run.py $*

--- a/backends/simulator_rtcs/run.py
+++ b/backends/simulator_rtcs/run.py
@@ -3,7 +3,7 @@ from qat.purr.compiler.frontends import QASMFrontend
 import pickle
 import sys
 import json
-
+import time
 
 if len(sys.argv) != 5:
     print("Usage: python3.8 run.py <compiled_circuit.x> <results.json> <execution_metrics.json> <num_shots>")
@@ -25,7 +25,11 @@ config = CompilerConfig()
 config.results_format.binary_count()
 config.repeats = num_shots
 
+# Time measure
+start = time.time()
+end = time.time()
 results, execution_metrics = frontend.execute(instruction_builder, compiler_config=config)
+elapsed = {"elapsed_time": end - time}
 
 with open(results_filename, "w") as f:
     json.dump(results, f)


### PR DESCRIPTION
Main additions:
+ timer for the ZMQ.execute in qpu backend
+ qulacs backend for single-cpu
+ qulacs bachend for multi-cpu

TODO:
- A way to decide if single or multi-cpu when asking for qulacs backend. Probably based in the number of total qubits.
- More information comming back from qulacs backend. Observables, state entropy...

